### PR TITLE
Whitelist API

### DIFF
--- a/src/main/scala/com/risksense/whitelist/Whitelist.scala
+++ b/src/main/scala/com/risksense/whitelist/Whitelist.scala
@@ -1,0 +1,107 @@
+/**
+  * Copyright 2017 RiskSense, Inc.
+  * This file is part of ipaddr library.
+  *
+  * Ipaddr is free software licensed under the Apache License, Version 2.0 (the "License"); you
+  * may not use this file except in compliance with the License. You may obtain a copy of the
+  * License at
+  *
+  *         http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software distributed under the
+  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  * express or implied. See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package com.risksense.whitelist
+
+import com.risksense.ipaddr.IpAddress
+import com.risksense.ipaddr.IpaddrException
+import com.risksense.ipaddr.IpGlob
+import com.risksense.ipaddr.IpNetwork
+import com.risksense.ipaddr.IpRange
+import com.risksense.ipaddr.IpSet
+
+/**
+  * Utility for checking whitelist inclusion as well as IP/CIDR string
+  * representation validity.
+  */
+object Whitelist {
+  def isAllowed (ipInfo: IpAddress, whitelist: IpSet): Boolean =
+    whitelist.contains(ipInfo)
+
+  def isAllowed (ipInfo: IpNetwork, whitelist: IpSet): Boolean =
+    whitelist.contains(ipInfo)
+
+  def isAllowed (ipInfo: IpRange, whitelist: IpSet): Boolean = {
+    ipInfo.cidrs.foldLeft(true) {
+      (res, net) => {
+        res && whitelist.contains(net)
+      }
+    }
+  }
+
+  def isAllowed (ipGlob: String, whitelist: IpSet): Boolean = {
+    ipGlob match {
+      case _ if (ipGlob.isEmpty) => false
+      case _ if (!IpGlob.validGlob(ipGlob)) => false
+      case _ => isAllowed(IpGlob.globToIpRange(ipGlob), whitelist)
+    }
+  }
+
+  def isValidIPSyntax(ipDescriptor: String): Boolean = {
+    ipDescriptor match {
+      case _ if (ipDescriptor.isEmpty) => false
+      case _ if (ipDescriptor.contains("-") || ipDescriptor.contains("*")) =>
+        IpGlob.validGlob(ipDescriptor)
+      case _ if (!ipDescriptor.contains('/')) => {
+        try {
+          IpAddress(ipDescriptor)
+          true
+        }
+        catch {
+          case e: IpaddrException => false
+        }
+      }
+      case _ if (ipDescriptor.contains('/')) => {
+        try {
+          IpNetwork(ipDescriptor)
+          true
+        }
+        catch {
+          case e: IpaddrException => false
+        }
+      }
+      case _ => false
+    }
+  }
+}
+
+abstract class Whitelist {
+  /**
+    * Check given IpAddress for inclusion in given IpSet (whitelist)
+    */
+  def isAllowed(ipInfo: IpAddress, whitelist: IpSet): Boolean
+
+  /**
+    * Check given IpNetwork for inclusion in given IpSet (whitelist)
+    */
+  def isAllowed(ipInfo: IpNetwork, whitelist: IpSet): Boolean
+
+  /**
+    * Check given IpRange for inclusion in given IpSet (whitelist)
+    * Note: true only if every IP in range is within whitelist.
+    */
+  def isAllowed(ipInfo: IpRange, whitelist: IpSet): Boolean
+
+  /**
+    * Check given IpGlob string rep. for inclusion in given IpSet (whitelist)
+    */
+  def isAllowed(ipInfo: String, whitelist: IpSet): Boolean
+
+  /**
+    * Check the validity of a given string in relation to valid IP/CIDR/Glob.
+    */
+  def isValidIPSyntax(ipDescriptor: String): Boolean
+}

--- a/src/test/scala/com/risksense/ipaddr/WhitelistTest.scala
+++ b/src/test/scala/com/risksense/ipaddr/WhitelistTest.scala
@@ -1,0 +1,113 @@
+/**
+  * Copyright 2017 RiskSense, Inc.
+  * This file is part of ipaddr library.
+  *
+  * Ipaddr is free software licensed under the Apache License, Version 2.0 (the "License"); you
+  * may not use this file except in compliance with the License. You may obtain a copy of the
+  * License at
+  *
+  *         http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software distributed under the
+  * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  * express or implied. See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+package com.risksense.ipaddr
+
+import com.risksense.whitelist.Whitelist
+
+// scalastyle:off multiple.string.literals magic.number
+
+class WhitelistTest extends UnitSpec {
+  private val whitelist = IpSet(IpRange("5.5.5.5", "5.5.5.10"))
+
+  private val validGlobList = List(
+    "5.5.5.*",
+    "5.5.*.*",
+    "5.*.*.*",
+    "*.*.*.*",
+    "5.5.5.5-10",
+    "5.5.5-10.*",
+    "5.5-10.*.*")
+
+  private val invalidGlobList = List(
+    "5.5.*.5-10",
+    "5.*.5-10.5",
+    "5.5.5.6-5")
+
+  private val octet = List(0, 255)
+  private val validIPs = for { i <- octet; j <- octet; k <- octet; l <- octet } yield {
+    List(i, j, k, l).mkString(".")
+  }
+  private val outOfRangeIPs = validIPs.filter((e) => !whitelist.contains(IpAddress(e)))
+
+  "Valid IP/CIDR/Glob" should "be contained in whitelist (5.5.5.5-10)" in {
+    Whitelist.isAllowed(IpAddress("5.5.5.5"), whitelist) should be(true)
+    Whitelist.isAllowed(IpAddress("5.5.5.6"), whitelist) should be(true)
+    Whitelist.isAllowed(IpAddress("5.5.5.7"), whitelist) should be(true)
+    Whitelist.isAllowed(IpAddress("5.5.5.8"), whitelist) should be(true)
+    Whitelist.isAllowed(IpAddress("5.5.5.9"), whitelist) should be(true)
+    Whitelist.isAllowed(IpAddress("5.5.5.10"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.5"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.6"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.7"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.8"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.9"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.10"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.5/32"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.6/31"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.8/31"), whitelist) should be(true)
+    Whitelist.isAllowed(IpNetwork("5.5.5.10/32"), whitelist) should be(true)
+    Whitelist.isAllowed(IpRange("5.5.5.5", "5.5.5.10"), whitelist) should be(true)
+    Whitelist.isAllowed("5.5.5.5", whitelist) should be(true)
+    Whitelist.isAllowed("5.5.5.6", whitelist) should be(true)
+    Whitelist.isAllowed("5.5.5.7", whitelist) should be(true)
+    Whitelist.isAllowed("5.5.5.8", whitelist) should be(true)
+    Whitelist.isAllowed("5.5.5.9", whitelist) should be(true)
+    Whitelist.isAllowed("5.5.5.10", whitelist) should be(true)
+    Whitelist.isAllowed("5.5.5.5-10", whitelist) should be(true)
+  }
+
+  "Valid IP/CIDR/Glob out of range" should "not be in whitelist" in {
+    for ( validNotInRangeIp <- outOfRangeIPs ) {
+      Whitelist.isAllowed(IpAddress(validNotInRangeIp), whitelist) should be(false)
+      Whitelist.isAllowed(IpNetwork(validNotInRangeIp), whitelist) should be(false)
+    }
+  }
+
+  "Correctly constructed IP/CIDR/Glob" should "be pass validation" in {
+    //valid ip
+    for (validIp <- validIPs) {
+      Whitelist.isValidIPSyntax(validIp) should be(true)
+    }
+
+    //valid cidr
+    val cidr = List(0, 32)
+    for (validCIDR <- cidr) {
+      Whitelist.isValidIPSyntax("5.5.5.5/" + validCIDR.toString) should be(true)
+    }
+
+    //valid glob
+    for (glob <- validGlobList) {
+      Whitelist.isValidIPSyntax(glob) should be(true)
+    }
+  }
+
+  "Incorrectly constructed IP/CIDR/Glob" should "not pass validation" in {
+    //bad ip
+    Whitelist.isValidIPSyntax("192.0.0") should be(false)
+    Whitelist.isValidIPSyntax("") should be(false)
+
+    //bad cidr
+    for (validIp <- validIPs) {
+      Whitelist.isValidIPSyntax(validIp + "/33") should be(false)
+    }
+
+    //bad glob
+    for (glob <- invalidGlobList) {
+      Whitelist.isValidIPSyntax(glob) should be(false)
+    }
+  }
+}


### PR DESCRIPTION
Why:
 * Proposing utility API for use when managing IP Whitelists.

How:
 * Introduction of the Whitelist object.
 * Inclusion of two functions (with multiple signatures):
 * - isAllowed: can be given IpAddress/IpNetwork/IpRange/Glob as well as
 * an IpSet (the whitelist) to check for inclusion.
 * Note: Glob param is a string representation
 * - isValidIPSyntax: Can be given a string representation of an
 * IP/CIDR/Glob and the function will return with whether or not the
 * input is valid representation of IP/CIDR/Glob.