### PR TITLE
RS-6485 Remove scalactic dependency from ipaddr library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "ipaddr",
     organization := "com.risksense",
-    version := "1.0.0",
+    version := "1.0.1",
     resolvers ++= Seq(
       "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
     ),
@@ -22,7 +22,6 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % "1.1.7",
       "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
-      "org.scalactic" %% "scalactic" % "3.0.1",
       "org.scalatest" %% "scalatest" % "3.0.1" % "test"
     )
   )


### PR DESCRIPTION
Why:
* This dependency is causing issues in nearly all rest-api test suites by trying to force
implementation of unnecessary methods.

How:
* Remove the dependency from this library since it is never actually used.