### PR TITLE
Converted lengthy Sequences to Stream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,6 @@ lazy val root = (project in file("."))
     name := "ipaddr",
     organization := "com.risksense",
     version := "1.0.1",
-    resolvers ++= Seq(
-      "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
-    ),
     scalaVersion := "2.11.8",
     scalacOptions ++= Seq(
       "-feature",
@@ -25,4 +22,3 @@ lazy val root = (project in file("."))
       "org.scalatest" %% "scalatest" % "3.0.1" % "test"
     )
   )
-

--- a/src/main/scala/com/risksense/ipaddr/IpAddressMath.scala
+++ b/src/main/scala/com/risksense/ipaddr/IpAddressMath.scala
@@ -28,21 +28,20 @@ trait IpAddressMath {
   /** Add to IP address.
     *
     * Increases the numerical value of this IPAddress by 'n' and returns a new IpAddress object.
-    * An instance of IpError is returned if the result exceeds maximum IP address value or is less
-    * than zero.
     *
     * @param n size of IP address increment.
     * @return new IpAddress object with incremented address.
+    * @throws IpaddrException if the resulting address is not valid.
     */
   def +(n: Int): IpAddress = IpAddress(this.numerical + n)
 
   /** Subtract from IP address
     *
     * Decreases the numerical value of this IPAddress by n and returns a new IpAddress object.
-    * An IndexError is raised if result exceeds maximum IP address value or is less than zero.
     *
     * @param n size of IP address decrement.
     * @return new IpAddress object with decremented address.
+    * @throws IpaddrException if the resulting address is not valid.
     */
   def -(n: Int): IpAddress = IpAddress(this.numerical - n)
 

--- a/src/main/scala/com/risksense/ipaddr/IpRange.scala
+++ b/src/main/scala/com/risksense/ipaddr/IpRange.scala
@@ -98,7 +98,7 @@ class IpRange ( // scalastyle:ignore equals.hash.code
 
   /** Checks if a given [[IpNetwork]] belongs to this IpRange object.
     *
-    * @param that a Network object
+    * @param that an IpNetwork object
     * @return True if input network belongs to this IpRange, False otherwise.
     */
   def contains(that: IpNetwork): Boolean = {
@@ -112,12 +112,12 @@ class IpRange ( // scalastyle:ignore equals.hash.code
   /** Returns a sequence of [[IpNetwork]] objects found within the lower and upper bound addresses
     * of this IpRange.
     *
-    * @return Sequence of Network objects
+    * @return Sequence of IpNetwork objects
     */
   def cidrs: Seq[IpNetwork] = {
     val firstNetwork = IpNetwork(this.start, this.start.netmaskBits)
     val lastNetwork = IpNetwork(this.end, this.end.netmaskBits)
-    BaseIp.ipRangeToCidrs(firstNetwork, lastNetwork)
+    BaseIp.boundedNetworkSeq(firstNetwork, lastNetwork)
   }
 
   /** Override `equals`.
@@ -158,7 +158,7 @@ object IpRange {
     *
     * @param start Lower bound IP address in string format
     * @param end Upper bound IP address in string format
-    * @return Either IpRange if input addresses are valid, IpError otherwise.
+    * @return IpRange if input addresses are valid
     */
   @throws(classOf[IpaddrException])
   def apply(start: String, end: String): IpRange = new IpRange(IpAddress(start), IpAddress(end))

--- a/src/main/scala/com/risksense/ipaddr/IpSet.scala
+++ b/src/main/scala/com/risksense/ipaddr/IpSet.scala
@@ -20,7 +20,7 @@ import scala.annotation.tailrec
 import scala.collection.SortedSet
 import scala.util.hashing.MurmurHash3
 
-/** Represents an unordered collection (set) of Network elements.
+/** Represents an unordered collection (set) of IpNetwork elements.
   *
   * @constructor creates a new IpSet.
   * @param networkSeq a sorted sequence of [[IpNetwork]] objects.
@@ -51,6 +51,8 @@ case class IpSet private[ipaddr] (networkSeq: IndexedSeq[IpNetwork]) // scalasty
     *
     * IpRange equivalent to this IpSet only if all its members form a single contiguous sequence,
     * otherwise generates a IpaddrException.
+    *
+    * @note This can be resource intensive if the address space is huge.
     */
   @throws(classOf[IpaddrException])
   lazy val ipRange: IpRange = {
@@ -58,8 +60,8 @@ case class IpSet private[ipaddr] (networkSeq: IndexedSeq[IpNetwork]) // scalasty
       if (networkSeq.isEmpty) {
         throw new IpaddrException("Cannot create IpRange from an empty IpSet.")
       } else {
-        val ip1 = IpAddress(networkSeq.head.iter.head)
-        val ip2 = IpAddress(networkSeq.last.iter.last)
+        val ip1 = IpAddress(networkSeq.head.allHosts.head)
+        val ip2 = IpAddress(networkSeq.last.allHosts.last)
         new IpRange(ip1, ip2)
       }
     } else {
@@ -105,7 +107,7 @@ case class IpSet private[ipaddr] (networkSeq: IndexedSeq[IpNetwork]) // scalasty
     */
   def canEquals(other: Any): Boolean = other.isInstanceOf[IpSet]
 
-  /** Checks if every Network in this [[IpSet]] is present in that IpSet and vice-versa.
+  /** Checks if every IpNetwork in this [[IpSet]] is present in that IpSet and vice-versa.
     *
     * @param that an IpSet to match this IpSet with
     * @return True if all networks match, False otherwise.
@@ -131,13 +133,13 @@ case class IpSet private[ipaddr] (networkSeq: IndexedSeq[IpNetwork]) // scalasty
     this + newNetwork
   }
 
-  /** Add a Network to this IpSet
+  /** Add a IpNetwork to this IpSet
     *
     * Adds a [[IpNetwork]] to this IpSet and returns a new IpSet. Where possible the input Network
     * is merged with other Networks of `this` set to form more concise blocks.
     *
-    * @param that a Network object.
-    * @return an IpSet resulting from addition of `that` Network to `this`
+    * @param that a IpNetwork object.
+    * @return an IpSet resulting from addition of `that` IpNetwork to `this`
     */
   def +(that: IpNetwork): IpSet = { // scalastyle:ignore method.name
     if (this.contains(that)) {
@@ -181,7 +183,7 @@ case class IpSet private[ipaddr] (networkSeq: IndexedSeq[IpNetwork]) // scalasty
     *
     * Removes a [[IpNetwork]] from this IpSet and returns a new IpSet.
     *
-    * @param that the Network object to remove from this IpSet.
+    * @param that the IpNetwork object to remove from this IpSet.
     * @return a new IpSet
     */
   def -(that: IpNetwork): IpSet = { // scalastyle:ignore method.name
@@ -296,8 +298,8 @@ case class IpSet private[ipaddr] (networkSeq: IndexedSeq[IpNetwork]) // scalasty
 
   /** Test if a given [[IpNetwork]] is present in this IpSet.
     *
-    * @param network a Network object
-    * @return True if input Network is present in this IpSet, False otherwise.
+    * @param network a IpNetwork object
+    * @return True if input IpNetwork is present in this IpSet, False otherwise.
     */
   def contains(network: IpNetwork): Boolean = this.exists(_.contains(network))
 
@@ -344,7 +346,7 @@ case class IpSet private[ipaddr] (networkSeq: IndexedSeq[IpNetwork]) // scalasty
      *
      * @param s1 `this` IpSets network sequence
      * @param s2 `that` IpSets network sequence
-     * @param result a sequence of Network objects common in `this` and `that`
+     * @param result a sequence of IpNetwork objects common in `this` and `that`
      */
     @tailrec
     def intersectRecurse(
@@ -408,7 +410,7 @@ object IpSet {
 
   /** Creates a new IpSet from the given [[IpNetwork]]
     *
-    * @param network a Network object
+    * @param network a IpNetwork object
     * @return an IpSet
     */
   def apply(network: IpNetwork): IpSet = IpSet(Seq(network))
@@ -429,7 +431,7 @@ object IpSet {
 
   /** Creates a new IpSet from a sequence of [[IpNetwork]] objects.
     *
-    * @param netSeq a sequence of Network objects
+    * @param netSeq a sequence of IpNetwork objects
     * @return an IpSet
     */
   def apply(netSeq: Seq[IpNetwork]): IpSet = {

--- a/src/main/scala/com/risksense/ipaddr/Ipv4.scala
+++ b/src/main/scala/com/risksense/ipaddr/Ipv4.scala
@@ -168,24 +168,23 @@ object Ipv4 {
     * Expands a partial IPv4 address into a full 4-octet version and also checks the validity of
     * the expanded address.
     *
-    * @param address a partial or abbreviated IPv4 address
+    * @param partialAddress a partial or abbreviated IPv4 address
     * @return an expanded IP address in presentation format (x.x.x.x)
     *
     * @example 192 -> returns Some("192.0.0.0") because the result is valid address <br/>
     * 256 -> returns None because address `256.0.0.0` is invalid
     */
-  def expandPartialAddress(address: String): Option[String] = {
-    val res = address match {
-      case Net1Regex(_*) => Some(address + ".0.0.0")
-      case Net2Regex(_*) => Some(address + ".0.0")
-      case Net3Regex(_*) => Some(address + ".0")
-      case Net4Regex(_*) => Some(address)
+  def expandPartialAddress(partialAddress: String): Option[String] = {
+    val completeAddress = partialAddress match {
+      case Net1Regex(_*) => Some(partialAddress + ".0.0.0")
+      case Net2Regex(_*) => Some(partialAddress + ".0.0")
+      case Net3Regex(_*) => Some(partialAddress + ".0")
+      case Net4Regex(_*) => Some(partialAddress)
       case _ => None
     }
-    if (res.isDefined && isValidAddress(res.get)) {
-      res
-    } else {
-      None
+    completeAddress match {
+      case Some(addr) if isValidAddress(addr) => Some(addr)
+      case _ => None
     }
   }
 

--- a/src/test/scala/com/risksense/ipaddr/BaseIpTest.scala
+++ b/src/test/scala/com/risksense/ipaddr/BaseIpTest.scala
@@ -33,8 +33,7 @@ class BaseIpTest extends UnitSpec {
     val spanNet2 = IpNetwork("0.0.0.0/0")
     BaseIp.spanningCidr(Seq(net1, net2)) should be(spanNet1)
     BaseIp.spanningCidr(Seq(net3, net4)) should be(spanNet2)
-    an[IpaddrException] should be thrownBy
-      BaseIp.spanningCidr(Seq(spanNet1))
+    an[IpaddrException] should be thrownBy BaseIp.spanningCidr(Seq(spanNet1))
   }
 
   "CidrExclude" should "work properly" in {
@@ -77,7 +76,6 @@ class BaseIpTest extends UnitSpec {
   }
 
   "allMatchingCidrs" should "match all networks for a valid address" in {
-    // scalastyle:ignore underscore.import import.grouping
     val networks = nets.map(IpNetwork(_))
     BaseIp.allMatchingCidrs("10.2.1.2", nets) should be(networks.drop(1))
     BaseIp.allMatchingCidrs(addr1, nets) should be(Nil)

--- a/src/test/scala/com/risksense/ipaddr/IpAddressTest.scala
+++ b/src/test/scala/com/risksense/ipaddr/IpAddressTest.scala
@@ -42,7 +42,7 @@ class IpAddressTest extends UnitSpec {
     List(i, j, k, l).mkString(".")
   }).tail
 
-  "Creating an IpAddress" should "result in IpError if address is invalid" in {
+  "Creating an IpAddress" should "result in IpaddrException if address is invalid" in {
     an[IpaddrException] should be thrownBy IpAddress("192.168.1")
     an[IpaddrException] should be thrownBy IpAddress(4294967296L)
     for { invalidIp <- ipInvalidStrings } {

--- a/src/test/scala/com/risksense/ipaddr/IpNetworkTest.scala
+++ b/src/test/scala/com/risksense/ipaddr/IpNetworkTest.scala
@@ -35,7 +35,7 @@ class IpNetworkTest extends UnitSpec {
   private val range2 = IpRange(netAddr, netAddr3)
   private val range3 = IpRange(netAddr4, netAddr2)
 
-  "Creating a Network " should "result in IpError if address is invalid" in {
+  "Creating an IpNetwork " should "result in IpaddrException if address is invalid" in {
     an[IpaddrException] should be thrownBy IpNetwork("192.168.256/24")
     an[IpaddrException] should be thrownBy IpNetwork("192.168.256/256.255.255.0")
   }
@@ -99,13 +99,11 @@ class IpNetworkTest extends UnitSpec {
     (net1 == "1.2.3.4") should be(false)
   }
 
-  it should "perform iterHosts operation" in {
-    val maxNet = IpNetwork("255.255.255.255/30")
-    val n1 = IpNetwork("192.168.1.1/32")
-    an[IpaddrException] should be thrownBy maxNet.next()
-    maxNet.iterHosts.size should be(2)
-    n1.iterHosts should be('empty)
-    n1.iter.toString should be("Vector(192.168.1.1)")
+  it should "perform allHosts operation" in {
+    IpNetwork("192.168.1.1/30").allHosts.force should be(
+      Seq(IpAddress("192.168.1.0"), IpAddress("192.168.1.1"),
+          IpAddress("192.168.1.2"), IpAddress("192.168.1.3"))
+    )
   }
 
   "Network object" should "not contain bad input" in {


### PR DESCRIPTION
* IpNetwork's `allHosts` method was returning a sequence of IpAddress elements. This was a problem
  for large networks, particuarly anything below /10. To solve this, a Stream is returned instead.

* Scaladoc and code style corrections