### PR TITLE
Fail to generate large amount of subnets due to Integer Overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ library for Python. Examples in this readme are taken from [here](https://netadd
 ## Usage
 Add the following to your build.sbt:
 
-`libraryDependencies += "com.risksense" % "ipaddr_2.12" % "1.0.2"`
+`libraryDependencies += "com.risksense" % "ipaddr_2.12" % "1.0.3"`
 
 ## Tutorial
   * [IpAddress](#ipaddress)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file("."))
   .settings(
     name := "ipaddr",
     organization := "com.risksense",
-    version := "1.0.2",
+    version := "1.0.3",
     scalaVersion := "2.12.6",
     scalacOptions ++= Seq(
       "-feature",

--- a/src/main/scala/com/risksense/ipaddr/IpNetwork.scala
+++ b/src/main/scala/com/risksense/ipaddr/IpNetwork.scala
@@ -181,8 +181,7 @@ class IpNetwork private[ipaddr](
     if (prefix < 0 || prefix > this.ipAddr.width || prefix < this.mask) {
       Nil
     } else {
-      val maxSubnets = scala.math.pow(2, this.ipAddr.width - this.mask).toInt /
-        scala.math.pow(2, this.ipAddr.width - prefix).toInt
+      val maxSubnets = scala.math.pow(2, prefix - this.mask).toInt
       val countNew = count match {
         case 0 => maxSubnets
         case _ => count

--- a/src/test/scala/com/risksense/ipaddr/IpNetworkTest.scala
+++ b/src/test/scala/com/risksense/ipaddr/IpNetworkTest.scala
@@ -74,6 +74,12 @@ class IpNetworkTest extends UnitSpec {
     net1.subnet(26).size should be(4) // scalastyle:ignore
     net1.subnet(26).size should be(4)
     net1.subnet(33) should be(Nil)
+
+    val largeAmountOfSubnets = net6.subnet(17, 100000)
+
+    largeAmountOfSubnets.size should be (100000)
+    largeAmountOfSubnets.forall(s => s.mask == 17) should be(true)
+
   }
 
   it should "perform next operation" in {


### PR DESCRIPTION
I fixed (& simplified) the maxSubnets calculation in the subnet() method of the IpNetwork class and added a testcase which was failing before.